### PR TITLE
Replace Coffré by Plastron

### DIFF
--- a/packs/item-database.pack.json
+++ b/packs/item-database.pack.json
@@ -2818,7 +2818,7 @@
         },
         "item-database.json/items/337/name": {
                 "orig": "Bronze Chest Plate",
-                "text": "Coffré de Bronze",
+                "text": "Plastron de Bronze",
                 "note": "seriously hard to translate with that smallish size"
         },
         "item-database.json/items/337/description": {
@@ -2827,7 +2827,7 @@
         },
         "item-database.json/items/338/name": {
                 "orig": "Silver Chest Plate",
-                "text": "Coffré d'Argent"
+                "text": "Plastron d'Argent"
         },
         "item-database.json/items/338/description": {
                 "orig": "Armor crafted from silver chests. Strong against werewolves, weak against keys.",
@@ -2835,7 +2835,7 @@
         },
         "item-database.json/items/339/name": {
                 "orig": "Golden Chest Plate",
-                "text": "Coffré d'Or"
+                "text": "Plastron d'Or"
         },
         "item-database.json/items/339/description": {
                 "orig": "Armor crafted from golden chests. Stronger than it has any right to be.",


### PR DESCRIPTION
Coffré is the past-tense of coffrer, nothing to do with armor, so I replaced it by Plastron which means Chest Plate